### PR TITLE
fix: default action of touchend

### DIFF
--- a/MultiPicker/MultiPicker.js
+++ b/MultiPicker/MultiPicker.js
@@ -144,7 +144,7 @@
 					}, false);
 					tempDomUl.addEventListener('touchend', function () {
 						_this.touch(event, _this, tempDomUl, tempArray, i);
-					}, false);
+					}, true);
 				});
 			} else {
 				for ( var j = _this.ulCount - 1; j > _this.idxArr.length - 1; j-- ) {


### PR DESCRIPTION
fix warning in chrome
```
Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```
see alse: http://stackoverflow.com/questions/26478267/touch-move-getting-stuck-ignored-attempt-to-cancel-a-touchmove